### PR TITLE
Handle category IDs which are not UUID and slight refactoring

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/api/TerminologyRestController.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/api/TerminologyRestController.java
@@ -44,7 +44,14 @@ public class TerminologyRestController {
 
   @GetMapping("selectable-entries")
   public List<TerminologyEntry> getSelectableEntries(@RequestParam("query") String query,
-      @RequestParam(value = "categoryId", required = false) UUID categoryId) {
-    return terminologyService.getSelectableEntries(query, categoryId);
+      @RequestParam(value = "categoryId", required = false) String categoryId) {
+    UUID categoryUuid = null;
+    try {
+      // TODO: Use String (instead of UUID) to be fault tolerant
+      categoryUuid = UUID.fromString(categoryId);
+    } catch (Exception e) {
+      // use null
+    }
+    return terminologyService.getSelectableEntries(query, categoryUuid);
   }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/model/ui/CategoryEntry.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/model/ui/CategoryEntry.java
@@ -13,6 +13,11 @@ public class CategoryEntry {
     this.display = display;
   }
 
+  public CategoryEntry(TerminologyEntry terminologyEntry) {
+    this.catId = terminologyEntry.getId();
+    this.display = terminologyEntry.getDisplay();
+  }
+
   public String getDisplay() {
     return display;
   }


### PR DESCRIPTION
When a category ID is send but it is not a UUID we got a NullPointerException. We now avoid this NPE.

Also, I suggest a slight refactoring using an abstraction and streams rather than programmatic logic.