### PR TITLE
Implement Web Client Provider

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFBrokerClient.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFBrokerClient.java
@@ -2,9 +2,9 @@ package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
 
 
 import de.numcodex.feasibility_gui_backend.service.query_executor.BrokerClient;
-import de.numcodex.feasibility_gui_backend.service.query_executor.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryStatusListener;
+import de.numcodex.feasibility_gui_backend.service.query_executor.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.UnsupportedMediaTypeException;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ public final class DSFBrokerClient implements BrokerClient {
     }
 
     @Override
-    public void addQueryStatusListener(QueryStatusListener queryStatusListener) {
+    public void addQueryStatusListener(QueryStatusListener queryStatusListener) throws IOException {
         queryResultCollector.addResultListener(queryStatusListener);
     }
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFFhirSecurityContextProvider.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFFhirSecurityContextProvider.java
@@ -1,0 +1,54 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import de.rwh.utils.crypto.CertificateHelper;
+import de.rwh.utils.crypto.io.CertificateReader;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+
+/**
+ * An entity that can provide a security context for communicating with a FHIR server.
+ */
+public class DSFFhirSecurityContextProvider implements FhirSecurityContextProvider {
+
+    private final String keyStoreFile;
+    private final char[] keyStorePassword;
+    private final String certificateFile;
+
+    public DSFFhirSecurityContextProvider(String keyStoreFile, char[] keyStorePassword, String certificateFile) {
+        this.keyStoreFile = keyStoreFile;
+        this.keyStorePassword = keyStorePassword;
+        this.certificateFile = certificateFile;
+    }
+
+    @Override
+    public FhirSecurityContext provideSecurityContext() throws FhirSecurityContextProvisionException {
+        try {
+            Path localWebsocketKsFile = Paths.get(keyStoreFile);
+            if (!Files.isReadable(localWebsocketKsFile)) {
+                throw new IOException("Keystore file '" + localWebsocketKsFile.toString() + "' not readable");
+            }
+            KeyStore localKeyStore = CertificateReader.fromPkcs12(localWebsocketKsFile, keyStorePassword);
+            KeyStore localTrustStore = CertificateHelper.extractTrust(localKeyStore);
+
+            if (!Files.isReadable(Paths.get(certificateFile))) {
+                throw new IOException("Certificate file '" + certificateFile + "' not readable");
+            }
+            FileInputStream inStream = new FileInputStream(certificateFile);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            Certificate cert = cf.generateCertificate(inStream);
+
+            localTrustStore.setCertificateEntry("zars", cert);
+
+            return new FhirSecurityContext(localKeyStore, localTrustStore, keyStorePassword);
+        } catch (Exception e) {
+            throw new FhirSecurityContextProvisionException(e);
+        }
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFFhirWebClientProvider.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFFhirWebClientProvider.java
@@ -1,0 +1,157 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.highmed.dsf.fhir.service.ReferenceCleanerImpl;
+import org.highmed.dsf.fhir.service.ReferenceExtractorImpl;
+import org.highmed.fhir.client.FhirWebserviceClient;
+import org.highmed.fhir.client.FhirWebserviceClientJersey;
+import org.highmed.fhir.client.WebsocketClient;
+import org.highmed.fhir.client.WebsocketClientTyrus;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Subscription;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType.WEBSOCKET;
+import static org.hl7.fhir.r4.model.Subscription.SubscriptionStatus.ACTIVE;
+import static org.hl7.fhir.r4.model.Task.TaskStatus.COMPLETED;
+
+/**
+ * An entity that can provide different kinds of web clients to communicate with a FHIR server.
+ */
+class DSFFhirWebClientProvider implements FhirWebClientProvider {
+
+    private static final String QUERY_RESULT_SUBSCRIPTION_REASON = "Waiting for query results";
+    private static final String QUERY_RESULT_SUBSCRIPTION_CHANNEL_PAYLOAD = "application/fhir+json";
+    private static final String CODE_SYSTEM_AUTHORIZATION_ROLE = "http://highmed.org/fhir/CodeSystem/authorization-role";
+    private static final String CODE_SYSTEM_AUTHORIZATION_ROLE_VALUE_LOCAL = "LOCAL";
+
+    private final FhirContext fhirContext;
+    private final String webserviceBaseUrl;
+    private final int webserviceReadTimeout;
+    private final int webserviceConnectTimeout;
+    private final String websocketUrl;
+    private final FhirSecurityContextProvider securityContextProvider;
+    private FhirSecurityContext securityContext;
+
+    public DSFFhirWebClientProvider(FhirContext fhirContext, String webserviceBaseUrl, int webserviceReadTimeout,
+                                    int webserviceConnectTimeout, String websocketUrl,
+                                    FhirSecurityContextProvider securityContextProvider) {
+        this.fhirContext = fhirContext;
+        this.webserviceBaseUrl = webserviceBaseUrl;
+        this.webserviceReadTimeout = webserviceReadTimeout;
+        this.webserviceConnectTimeout = webserviceConnectTimeout;
+        this.websocketUrl = websocketUrl;
+        this.securityContextProvider = securityContextProvider;
+    }
+
+    @Override
+    public FhirWebserviceClient provideFhirWebserviceClient() throws FhirWebClientProvisionException {
+        if (securityContext == null) {
+            try {
+                securityContext = securityContextProvider.provideSecurityContext();
+            } catch (FhirSecurityContextProvisionException e) {
+                throw new FhirWebClientProvisionException(e);
+            }
+        }
+
+        ReferenceExtractorImpl extractor = new ReferenceExtractorImpl();
+        ReferenceCleanerImpl cleaner = new ReferenceCleanerImpl(extractor);
+
+        return new FhirWebserviceClientJersey(
+                webserviceBaseUrl,
+                securityContext.getTrustStore(),
+                securityContext.getKeyStore(),
+                securityContext.getKeyStorePassword(),
+                null,
+                null,
+                null,
+                webserviceConnectTimeout,
+                webserviceReadTimeout,
+                null,
+                fhirContext,
+                cleaner);
+    }
+
+    @Override
+    public WebsocketClient provideFhirWebsocketClient() throws FhirWebClientProvisionException {
+        if (securityContext == null) {
+            try {
+                securityContext = securityContextProvider.provideSecurityContext();
+            } catch (FhirSecurityContextProvisionException e) {
+                throw new FhirWebClientProvisionException(e);
+            }
+        }
+
+        FhirWebserviceClient fhirClient = provideFhirWebserviceClient();
+
+        String subscriptionId = searchForExistingQueryResultSubscription(fhirClient)
+                .orElseGet(createQueryResultSubscription(fhirClient))
+                .getIdElement().getIdPart();
+
+        // TODO: implement reconnector
+        return new WebsocketClientTyrus(() -> {
+        },
+                URI.create(websocketUrl),
+                securityContext.getTrustStore(),
+                securityContext.getKeyStore(),
+                securityContext.getKeyStorePassword(),
+                subscriptionId);
+    }
+
+    /**
+     * Searches for an existing feasibility query result subscription and returns it if there is any.
+     *
+     * @return The subscription for query results.
+     */
+    private Optional<Subscription> searchForExistingQueryResultSubscription(FhirWebserviceClient fhirClient) {
+        Bundle bundle = fhirClient.searchWithStrictHandling(Subscription.class,
+                Map.of("criteria", Collections.singletonList("Task?status=" + COMPLETED.toCode()),
+                        "status", Collections.singletonList(ACTIVE.toCode()),
+                        "type", Collections.singletonList(WEBSOCKET.toCode()),
+                        "payload", Collections.singletonList(QUERY_RESULT_SUBSCRIPTION_CHANNEL_PAYLOAD)));
+
+        if (!Bundle.BundleType.SEARCHSET.equals(bundle.getType()))
+            throw new RuntimeException("Could not retrieve searchset for subscription search query, but got "
+                    + bundle.getType());
+        if (bundle.getTotal() == 0)
+            return Optional.empty();
+        if (bundle.getTotal() != 1)
+            throw new RuntimeException("Could not retrieve exactly one result for subscription search query");
+        if (!(bundle.getEntryFirstRep().getResource() instanceof Subscription))
+            throw new RuntimeException("Could not retrieve exactly one Subscription, but got "
+                    + bundle.getEntryFirstRep().getResource().getResourceType());
+
+        return Optional.of((Subscription) bundle.getEntryFirstRep().getResource());
+    }
+
+    /**
+     * Returns a function capable of supplying a newly created subscription for feasibility query results.
+     *
+     * @return Function for getting a subscription for feasibility query results.
+     */
+    private Supplier<Subscription> createQueryResultSubscription(FhirWebserviceClient fhirClient) {
+        return () -> {
+            Subscription subscription = new Subscription()
+                    .setStatus(ACTIVE)
+                    .setReason(QUERY_RESULT_SUBSCRIPTION_REASON)
+                    .setChannel(new Subscription.SubscriptionChannelComponent()
+                            .setType(WEBSOCKET)
+                            .setPayload(QUERY_RESULT_SUBSCRIPTION_CHANNEL_PAYLOAD))
+                    // TODO: use this criteria if DSF has implemented the _profile search parameter (make sure to also remove the profile check in the DSFQueryResultHandler class!)
+//                .setCriteria("Task?status=" + Task.TaskStatus.COMPLETED.toCode() + "&_profile=" + SINGLE_DIC_QUERY_RESULT_PROFILE);
+                    .setCriteria("Task?status=" + COMPLETED.toCode());
+
+            subscription.getMeta()
+                    .addTag()
+                    .setSystem(CODE_SYSTEM_AUTHORIZATION_ROLE)
+                    .setCode(CODE_SYSTEM_AUTHORIZATION_ROLE_VALUE_LOCAL);
+
+            return fhirClient.create(subscription);
+        };
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryResultHandler.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryResultHandler.java
@@ -26,15 +26,17 @@ class DSFQueryResultHandler {
     private static final String CODE_SYSTEM_MEASURE_POPULATION = "http://terminology.hl7.org/CodeSystem/measure-population";
     private static final String CODE_SYSTEM_MEASURE_POPULATION_VALUE_INITIAL_POPULATION = "initial-population";
 
-    private final FhirWebserviceClient client;
+    private final FhirWebClientProvider fhirWebClientProvider;
+    private FhirWebserviceClient fhirWebserviceClient;
 
     /**
      * Creates a new {@link DSFQueryResultHandler} instance for processing FHIR Task resources.
      *
-     * @param client FHIR webservice client for resolving references within a FHIR Task.
+     * @param fhirWebClientProvider Provider capable of providing a FHIR webservice client for communicating with a
+     *                              FHIR server via HTTP.
      */
-    public DSFQueryResultHandler(FhirWebserviceClient client) {
-        this.client = client;
+    public DSFQueryResultHandler(FhirWebClientProvider fhirWebClientProvider) {
+        this.fhirWebClientProvider = fhirWebClientProvider;
     }
 
     /**
@@ -122,8 +124,11 @@ class DSFQueryResultHandler {
      * @param measureReportId Identifies the measure report that shall be fetched.
      * @return The fetched measure report.
      */
-    private MeasureReport fetchMeasureReport(String measureReportId) {
-        return client.read(MeasureReport.class, measureReportId);
+    private MeasureReport fetchMeasureReport(String measureReportId) throws FhirWebClientProvisionException {
+        if (fhirWebserviceClient == null) {
+            fhirWebserviceClient = fhirWebClientProvider.provideFhirWebserviceClient();
+        }
+        return fhirWebserviceClient.read(MeasureReport.class, measureReportId);
     }
 
     /**

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFSpringConfig.java
@@ -2,62 +2,16 @@ package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
 
 import ca.uhn.fhir.context.FhirContext;
 import de.numcodex.feasibility_gui_backend.service.query_executor.BrokerClient;
-import de.rwh.utils.crypto.CertificateHelper;
-import de.rwh.utils.crypto.io.CertificateReader;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import org.highmed.dsf.fhir.service.ReferenceCleanerImpl;
-import org.highmed.dsf.fhir.service.ReferenceExtractorImpl;
-import org.highmed.fhir.client.FhirWebserviceClient;
-import org.highmed.fhir.client.FhirWebserviceClientJersey;
-import org.highmed.fhir.client.WebsocketClient;
-import org.highmed.fhir.client.WebsocketClientTyrus;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Subscription;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Supplier;
-
-import static org.hl7.fhir.r4.model.Subscription.SubscriptionChannelType.WEBSOCKET;
-import static org.hl7.fhir.r4.model.Subscription.SubscriptionStatus.ACTIVE;
-import static org.hl7.fhir.r4.model.Task.TaskStatus.COMPLETED;
-
 /**
  * Spring configuration for providing a {@link DSFBrokerClient} instance.
  */
-// TODO: Fix to work without running ZARS
-//
-//       @Configuration
+@Configuration
 public class DSFSpringConfig {
-
-    private static final String QUERY_RESULT_SUBSCRIPTION_REASON = "Waiting for query results";
-    private static final String QUERY_RESULT_SUBSCRIPTION_CHANNEL_PAYLOAD = "application/fhir+json";
-    //    private static final String SINGLE_DIC_QUERY_RESULT_PROFILE = "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/codex-task-single-dic-result-simple-feasibility";
-
-    @Data
-    @AllArgsConstructor
-    private static class SecurityContext {
-        KeyStore keyStore;
-        KeyStore trustStore;
-    }
 
     @Value("${de.num-codex.FeasibilityGuiBackend.dsf.security.keystore.p12file}")
     private String keyStoreFile;
@@ -90,14 +44,14 @@ public class DSFSpringConfig {
     }
 
     @Bean
-    QueryManager dsfQueryManager(FhirWebserviceClient client) {
-        return new DSFQueryManager(client, organizationId.replace(' ', '_'));
+    QueryManager dsfQueryManager(FhirWebClientProvider fhirWebClientProvider) {
+        return new DSFQueryManager(fhirWebClientProvider, organizationId.replace(' ', '_'));
     }
 
     @Bean
     QueryResultCollector queryResultCollector(QueryResultStore resultStore, FhirContext fhirContext,
-                                              WebsocketClient websocketClient, DSFQueryResultHandler resultHandler) {
-        return new DSFQueryResultCollector(resultStore, fhirContext, websocketClient, resultHandler);
+                                              FhirWebClientProvider webClientProvider, DSFQueryResultHandler resultHandler) {
+        return new DSFQueryResultCollector(resultStore, fhirContext, webClientProvider, resultHandler);
     }
 
     @Bean
@@ -106,8 +60,8 @@ public class DSFSpringConfig {
     }
 
     @Bean
-    DSFQueryResultHandler queryResultHandler(FhirWebserviceClient webserviceClient) {
-        return new DSFQueryResultHandler(webserviceClient);
+    DSFQueryResultHandler queryResultHandler(FhirWebClientProvider webClientProvider) {
+        return new DSFQueryResultHandler(webClientProvider);
     }
 
     @Bean
@@ -115,115 +69,16 @@ public class DSFSpringConfig {
         return FhirContext.forR4();
     }
 
-    @Bean
-    SecurityContext securityContext() throws IOException, CertificateException, NoSuchAlgorithmException,
-            KeyStoreException {
-        Path localWebsocketKsFile = Paths.get(keyStoreFile);
-        if (!Files.isReadable(localWebsocketKsFile)) {
-            throw new IOException("Keystore file '" + localWebsocketKsFile.toString() + "' not readable");
-        }
-        KeyStore localKeyStore = CertificateReader.fromPkcs12(localWebsocketKsFile, keyStorePassword);
-        KeyStore localTrustStore = CertificateHelper.extractTrust(localKeyStore);
-
-        if (!Files.isReadable(Paths.get(certificateFile))) {
-            throw new IOException("Certificate file '" + certificateFile + "' not readable");
-        }
-        FileInputStream inStream = new FileInputStream(certificateFile);
-        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        Certificate cert = cf.generateCertificate(inStream);
-
-        localTrustStore.setCertificateEntry("zars", cert);
-
-        return new SecurityContext(localKeyStore, localTrustStore);
-    }
 
     @Bean
-    FhirWebserviceClient fhirWebserviceClient(SecurityContext securityCtx) {
-
-        ReferenceExtractorImpl extractor = new ReferenceExtractorImpl();
-        ReferenceCleanerImpl cleaner = new ReferenceCleanerImpl(extractor);
-
-        return new FhirWebserviceClientJersey(
-                webserviceBaseUrl,
-                securityCtx.trustStore,
-                securityCtx.keyStore,
-                keyStorePassword,
-                null,
-                null,
-                null,
-                webserviceConnectTimeout,
-                webserviceReadTimeout,
-                null,
-                fhirContext(),
-                cleaner);
+    FhirSecurityContextProvider fhirSecurityContextProvider() {
+        return new DSFFhirSecurityContextProvider(keyStoreFile, keyStorePassword, certificateFile);
     }
+
 
     @Bean
-    WebsocketClient fhirWebsocketClient(FhirWebserviceClient fhirClient, SecurityContext securityCtx) {
-        // TODO: change to provider
-        String subscriptionId = searchForExistingQueryResultSubscription(fhirClient)
-                .orElseGet(createQueryResultSubscription(fhirClient))
-                .getIdElement().getIdPart();
-
-        // TODO: implement reconnector
-        return new WebsocketClientTyrus(() -> {
-        },
-                URI.create(websocketUrl),
-                securityCtx.trustStore,
-                securityCtx.keyStore,
-                keyStorePassword,
-                subscriptionId);
-    }
-
-    /**
-     * Searches for an existing feasibility query result subscription and returns it if there is any.
-     *
-     * @return The subscription for query results.
-     */
-    private Optional<Subscription> searchForExistingQueryResultSubscription(FhirWebserviceClient fhirClient) {
-        Bundle bundle = fhirClient.searchWithStrictHandling(Subscription.class,
-                Map.of("criteria", Collections.singletonList("Task?status=" + COMPLETED.toCode()),
-                        "status", Collections.singletonList(ACTIVE.toCode()),
-                        "type", Collections.singletonList(WEBSOCKET.toCode()),
-                        "payload", Collections.singletonList(QUERY_RESULT_SUBSCRIPTION_CHANNEL_PAYLOAD)));
-
-        if (!Bundle.BundleType.SEARCHSET.equals(bundle.getType()))
-            throw new RuntimeException("Could not retrieve searchset for subscription search query, but got "
-                    + bundle.getType());
-        if (bundle.getTotal() == 0)
-            return Optional.empty();
-        if (bundle.getTotal() != 1)
-            throw new RuntimeException("Could not retrieve exactly one result for subscription search query");
-        if (!(bundle.getEntryFirstRep().getResource() instanceof Subscription))
-            throw new RuntimeException("Could not retrieve exactly one Subscription, but got "
-                    + bundle.getEntryFirstRep().getResource().getResourceType());
-
-        return Optional.of((Subscription) bundle.getEntryFirstRep().getResource());
-    }
-
-    /**
-     * Returns a function capable of supplying a newly created subscription for feasibility query results.
-     *
-     * @return Function for getting a subscription for feasibility query results.
-     */
-    private Supplier<Subscription> createQueryResultSubscription(FhirWebserviceClient fhirClient) {
-        return () -> {
-            Subscription subscription = new Subscription()
-                    .setStatus(ACTIVE)
-                    .setReason(QUERY_RESULT_SUBSCRIPTION_REASON)
-                    .setChannel(new Subscription.SubscriptionChannelComponent()
-                            .setType(WEBSOCKET)
-                            .setPayload(QUERY_RESULT_SUBSCRIPTION_CHANNEL_PAYLOAD))
-                    // TODO: use this criteria if DSF has implemented the _profile search parameter (make sure to also remove the profile check in the DSFQueryResultHandler class!)
-//                .setCriteria("Task?status=" + Task.TaskStatus.COMPLETED.toCode() + "&_profile=" + SINGLE_DIC_QUERY_RESULT_PROFILE);
-                    .setCriteria("Task?status=" + COMPLETED.toCode());
-
-            subscription.getMeta()
-                    .addTag()
-                    .setSystem("http://highmed.org/fhir/CodeSystem/authorization-role")
-                    .setCode("LOCAL");
-
-            return fhirClient.create(subscription);
-        };
+    FhirWebClientProvider fhirWebClientProvider(FhirContext fhirContext, FhirSecurityContextProvider securityContextProvider) {
+        return new DSFFhirWebClientProvider(fhirContext, webserviceBaseUrl, webserviceReadTimeout,
+                webserviceConnectTimeout, websocketUrl, securityContextProvider);
     }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirSecurityContext.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirSecurityContext.java
@@ -1,0 +1,17 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.security.KeyStore;
+
+/**
+ * Holds information about how to securely communicate with a FHIR server.
+ */
+@Data
+@AllArgsConstructor
+class FhirSecurityContext {
+    KeyStore keyStore;
+    KeyStore trustStore;
+    private char[] keyStorePassword;
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirSecurityContextProvider.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirSecurityContextProvider.java
@@ -1,0 +1,15 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+/**
+ * Represents an entity capable of providing a security context for a FHIR web client.
+ */
+public interface FhirSecurityContextProvider {
+
+    /**
+     * Provides a {@link FhirSecurityContext} to be used when communicating with a FHIR server.
+     *
+     * @return A {@link FhirSecurityContext}.
+     * @throws FhirSecurityContextProvisionException If the security context can not be provisioned.
+     */
+    FhirSecurityContext provideSecurityContext() throws FhirSecurityContextProvisionException;
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirSecurityContextProvisionException.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirSecurityContextProvisionException.java
@@ -1,0 +1,10 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+/**
+ * Indicates that a FHIR security context could not be provisioned.
+ */
+public class FhirSecurityContextProvisionException extends Exception {
+    public FhirSecurityContextProvisionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirWebClientProvider.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirWebClientProvider.java
@@ -1,0 +1,28 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import org.highmed.fhir.client.FhirWebserviceClient;
+import org.highmed.fhir.client.WebsocketClient;
+
+/**
+ * Represents an entity capable of providing different kinds of FHIR web clients. Supported web client types are
+ * webservice (HTTP) and websocket.
+ */
+public interface FhirWebClientProvider {
+
+    /**
+     * Provides a {@link FhirWebserviceClient} to communicate with a FHIR server via HTTP.
+     *
+     * @return A {@link FhirWebserviceClient}.
+     * @throws FhirWebClientProvisionException If the webservice client can not be provisioned.
+     */
+    FhirWebserviceClient provideFhirWebserviceClient() throws FhirWebClientProvisionException;
+
+    /**
+     * Provides a {@link WebsocketClient} to communicate with a FHIR server via a websocket.
+     *
+     * @return A {@link WebsocketClient}.
+     * @throws FhirWebClientProvisionException If the websocket client can not be provisioned.
+     */
+    WebsocketClient provideFhirWebsocketClient() throws FhirWebClientProvisionException;
+
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirWebClientProvisionException.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/FhirWebClientProvisionException.java
@@ -1,0 +1,10 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+/**
+ * Indicates that a FHIR web client could not be provisioned.
+ */
+public class FhirWebClientProvisionException extends Exception {
+    public FhirWebClientProvisionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/QueryManager.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/QueryManager.java
@@ -1,9 +1,9 @@
 package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
 
-import java.io.IOException;
-
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.UnsupportedMediaTypeException;
+
+import java.io.IOException;
 
 /**
  * Represents an entity capable of managing different aspects of running distributed feasibility queries.
@@ -35,7 +35,7 @@ interface QueryManager {
      *
      * @param queryId Identifies the query that shall be published.
      * @throws QueryNotFoundException If the given query ID does not identify a known query.
-     * @throws PublishFailedException If the query identified by the given query ID can not be published.
+     * @throws IOException If the query identified by the given query ID can not be published.
      */
     void publishQuery(String queryId) throws QueryNotFoundException, IOException;
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/QueryResultCollector.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/QueryResultCollector.java
@@ -4,6 +4,7 @@ import de.numcodex.feasibility_gui_backend.service.query_executor.QueryNotFoundE
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryStatusListener;
 import de.numcodex.feasibility_gui_backend.service.query_executor.SiteNotFoundException;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -15,8 +16,9 @@ interface QueryResultCollector {
      * Registers a listener that gets called whenever a new query result comes in.
      *
      * @param listener The listener that gets notified for new results.
+     * @throws IOException If there is a problem when trying to establish a result listener channel.
      */
-    void addResultListener(QueryStatusListener listener);
+    void addResultListener(QueryStatusListener listener) throws IOException;
 
     /**
      * Gets the feasibility of a specific site within a query.

--- a/src/test/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryManagerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryManagerTest.java
@@ -36,12 +36,15 @@ public class DSFQueryManagerTest {
     @Mock
     private FhirWebserviceClient fhirWebserviceClient;
 
+    @Mock
+    private FhirWebClientProvider fhirWebClientProvider;
+
     private DSFQueryManager queryHandler;
     private String unknownQueryId;
 
     @BeforeEach
     public void setUp() {
-        this.queryHandler = new DSFQueryManager(fhirWebserviceClient, ORGANIZATION);
+        this.queryHandler = new DSFQueryManager(fhirWebClientProvider, ORGANIZATION);
         this.unknownQueryId = UUID.randomUUID().toString();
     }
 
@@ -98,9 +101,11 @@ public class DSFQueryManagerTest {
     }
 
     @Test
-    public void testPublishQuery() throws UnsupportedMediaTypeException, QueryNotFoundException, IOException {
+    public void testPublishQuery() throws UnsupportedMediaTypeException, QueryNotFoundException, IOException, FhirWebClientProvisionException {
         String queryId = queryHandler.createQuery();
         queryHandler.addQueryDefinition(queryId, "text/cql", "");
+
+        when(fhirWebClientProvider.provideFhirWebserviceClient()).thenReturn(fhirWebserviceClient);
         queryHandler.publishQuery(queryId);
 
         verify(fhirWebserviceClient).postBundle(bundleCaptor.capture());

--- a/src/test/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryResultHandlerTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryResultHandlerTest.java
@@ -31,6 +31,9 @@ public class DSFQueryResultHandlerTest {
     @Mock
     FhirWebserviceClient client;
 
+    @Mock
+    FhirWebClientProvider fhirWebClientProvider;
+
     @InjectMocks
     DSFQueryResultHandler handler;
 
@@ -52,7 +55,7 @@ public class DSFQueryResultHandlerTest {
     }
 
     @Test
-    public void testOnResultButReferencedMeasureReportCanNotBeFetched() {
+    public void testOnResultButReferencedMeasureReportCanNotBeFetched() throws FhirWebClientProvisionException {
         Reference dicOrganizationRef = new Reference().setIdentifier(new Identifier().setSystem("http://highmed.org/fhir/NamingSystem/organization-identifier").setValue("DIC"));
         Reference zarsOrganizationRef = new Reference().setIdentifier(new Identifier().setSystem("http://highmed.org/fhir/NamingSystem/organization-identifier").setValue("ZARS"));
 
@@ -76,6 +79,7 @@ public class DSFQueryResultHandlerTest {
                                 .setCode("measure-report-reference")))
                 .setValue(new Reference().setReference("MeasureReport/dfd68241-224d-4fd8-bd1a-7675682fa608"));
 
+        when(fhirWebClientProvider.provideFhirWebserviceClient()).thenReturn(client);
         Exception e = new RuntimeException("cannot fetch measure report");
         when(client.read(MeasureReport.class, "dfd68241-224d-4fd8-bd1a-7675682fa608")).thenThrow(e);
 
@@ -84,7 +88,7 @@ public class DSFQueryResultHandlerTest {
     }
 
     @Test
-    public void testOnResult() {
+    public void testOnResult() throws FhirWebClientProvisionException {
         Reference dicOrganizationRef = new Reference().setIdentifier(new Identifier().setSystem("http://highmed.org/fhir/NamingSystem/organization-identifier").setValue("DIC"));
         Reference zarsOrganizationRef = new Reference().setIdentifier(new Identifier().setSystem("http://highmed.org/fhir/NamingSystem/organization-identifier").setValue("ZARS"));
 
@@ -121,6 +125,7 @@ public class DSFQueryResultHandlerTest {
                                 .setCode("initial-population")))
                 .setCount(10);
 
+        when(fhirWebClientProvider.provideFhirWebserviceClient()).thenReturn(client);
         when(client.read(MeasureReport.class, "dfd68241-224d-4fd8-bd1a-7675682fa608")).thenReturn(report);
 
         Optional<DSFQueryResult> dsfQueryResult = handler.onResult(task);


### PR DESCRIPTION
Resolves #9.

Introduces a provider for different kinds of FHIR web clients. This helps with deferring object realization so that the backend can be started using the DSF path even if the middleware can't be reached at startup.