### PR TITLE
Improve CQL Translation Error Handling

### DIFF
--- a/ontology/conceptTree.json
+++ b/ontology/conceptTree.json
@@ -1,21 +1,37 @@
 {
   "termCode": {
-    "code": "C71",
-    "display": "B\u00f6sartige Neubildung des Gehirns",
-    "system": "http://fhir.de/CodeSystem/dimdi/icd-10-gm"
+    "code": "",
+    "display": "ROOT",
+    "system": ""
   },
   "children": [
     {
       "termCode": {
-        "code": "C71.1",
-        "display": "",
+        "code": "C71",
+        "display": "B\u00f6sartige Neubildung des Gehirns",
         "system": "http://fhir.de/CodeSystem/dimdi/icd-10-gm"
-      }
+      },
+      "children": [
+        {
+          "termCode": {
+            "code": "C71.1",
+            "display": "",
+            "system": "http://fhir.de/CodeSystem/dimdi/icd-10-gm"
+          }
+        },
+        {
+          "termCode": {
+            "code": "C71.2",
+            "display": "",
+            "system": "http://fhir.de/CodeSystem/dimdi/icd-10-gm"
+          }
+        }
+      ]
     },
     {
       "termCode": {
-        "code": "C71.2",
-        "display": "",
+        "code": "A16.2",
+        "display": "Lungentuberkulose ohne Angabe einer bakteriologischen, molekularbiologischen oder histologischen Sicherung",
         "system": "http://fhir.de/CodeSystem/dimdi/icd-10-gm"
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
       <artifactId>broker-client</artifactId>
       <version>1.2</version>
     </dependency>
-    
 
     <dependency>
       <groupId>org.highmed.dsf</groupId>
@@ -90,7 +89,7 @@
     <dependency>
       <groupId>de.numcodex</groupId>
       <artifactId>sq2cql</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.2</version>
     </dependency>
 
     <dependency>
@@ -116,5 +115,15 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>codex</id>
+      <name>GitHub num-codex Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/num-codex/codex-sq2cql</url>
+      <releases><enabled>true</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
 
 </project>

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_builder/CqlQueryBuilder.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_builder/CqlQueryBuilder.java
@@ -6,6 +6,8 @@ import de.numcodex.feasibility_gui_backend.model.query.StructuredQuery;
 import de.numcodex.sq2cql.PrintContext;
 import de.numcodex.sq2cql.Translator;
 import de.numcodex.sq2cql.model.cql.Library;
+import de.numcodex.sq2cql.model.structured_query.TranslationException;
+
 import java.util.Objects;
 
 public class CqlQueryBuilder implements QueryBuilder {
@@ -21,11 +23,17 @@ public class CqlQueryBuilder implements QueryBuilder {
     @Override
     public String getQueryContent(StructuredQuery query) throws QueryBuilderException {
         try {
-            var structuredQuery = objectMapper.readValue(objectMapper.writeValueAsString(query),
-                    de.numcodex.sq2cql.model.structured_query.StructuredQuery.class);
-
-            Library library = translator.toCql(structuredQuery);
+            Library library = translator.toCql(translateQuery(query));
             return library.print(PrintContext.ZERO);
+        } catch (TranslationException e) {
+            throw new QueryBuilderException("problem while translating a structured query into a CQL library", e);
+        }
+    }
+
+    private de.numcodex.sq2cql.model.structured_query.StructuredQuery translateQuery(StructuredQuery query) throws QueryBuilderException {
+        try {
+            return objectMapper.readValue(objectMapper.writeValueAsString(query),
+                        de.numcodex.sq2cql.model.structured_query.StructuredQuery.class);
         } catch (JsonProcessingException e) {
             throw new QueryBuilderException("problem while transforming structured query", e);
         }


### PR DESCRIPTION
Motivation came from executing manual build queries, staring with an empty one. Updated sq2cql to v0.1.2.