### PR TITLE
Loosen Media Type Restrictions for DSF

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/QueryHandlerService.java
@@ -13,24 +13,21 @@ import de.numcodex.feasibility_gui_backend.service.query_builder.QueryBuilderExc
 import de.numcodex.feasibility_gui_backend.service.query_executor.BrokerClient;
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryStatusListener;
-import de.numcodex.feasibility_gui_backend.service.query_executor.QueryStatusListenerImpl;
 import de.numcodex.feasibility_gui_backend.service.query_executor.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.UnsupportedMediaTypeException;
-import java.io.IOException;
-import java.util.Objects;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.util.Objects;
+
+import static de.numcodex.feasibility_gui_backend.service.QueryMediaTypes.CQL;
+import static de.numcodex.feasibility_gui_backend.service.QueryMediaTypes.FHIR;
+import static de.numcodex.feasibility_gui_backend.service.QueryMediaTypes.STRUCTURED_QUERY;
+
 @Service
 public class QueryHandlerService {
-
-  // TODO: Find correct media types
-  private static final String MEDIA_TYPE_STRUCT_QUERY = "text/structured-query";
-  private static final String MEDIA_TYPE_CQL = "text/cql";
-  private static final String MEDIA_TYPE_FHIR = "text/fhir-codex";
-
-
   private static final String UNKNOWN_SITE = "Unbekannter Standort";
 
   private final ObjectMapper objectMapper;
@@ -116,19 +113,19 @@ public class QueryHandlerService {
   private void addSqQuery(Query query, StructuredQuery structuredQuery)
       throws IOException {
     var sqContent = objectMapper.writeValueAsString(structuredQuery);
-    query.getContents().put(MEDIA_TYPE_STRUCT_QUERY, sqContent);
+    query.getContents().put(STRUCTURED_QUERY, sqContent);
   }
 
   private void addFhirQuery(Query query, StructuredQuery structuredQuery)
       throws QueryBuilderException {
     var fhirContent = getFhirContent(structuredQuery);
-    query.getContents().put(MEDIA_TYPE_FHIR, fhirContent);
+    query.getContents().put(FHIR, fhirContent);
   }
 
   private void addCqlQuery(Query query, StructuredQuery structuredQuery)
       throws QueryBuilderException {
     var cqlContent = getCqlContent(structuredQuery);
-    query.getContents().put(MEDIA_TYPE_CQL, cqlContent);
+    query.getContents().put(CQL, cqlContent);
   }
 
   private String getFhirContent(StructuredQuery structuredQuery) throws QueryBuilderException {

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/QueryMediaTypes.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/QueryMediaTypes.java
@@ -1,0 +1,22 @@
+package de.numcodex.feasibility_gui_backend.service;
+
+/**
+ * Holds information of media types regarding different query types supported by this application.
+ */
+public final class QueryMediaTypes {
+
+    /**
+     * Represents the media type of a structured query.
+     */
+    public static final String STRUCTURED_QUERY = "application/sq+json";
+
+    /**
+     * Represents the media type of a CQL query.
+     */
+    public static final String CQL = "text/cql";
+
+    /**
+     * Represents the media type of a FHIR search query.
+     */
+    public static final String FHIR = "text/fhir-codex";
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFMediaTypeTranslator.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFMediaTypeTranslator.java
@@ -1,0 +1,31 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import de.numcodex.feasibility_gui_backend.service.query_executor.UnsupportedMediaTypeException;
+
+import java.util.List;
+
+import static de.numcodex.feasibility_gui_backend.service.QueryMediaTypes.CQL;
+import static de.numcodex.feasibility_gui_backend.service.QueryMediaTypes.FHIR;
+import static de.numcodex.feasibility_gui_backend.service.QueryMediaTypes.STRUCTURED_QUERY;
+
+/**
+ * Utility for translating backend defined query media types into their corresponding DSF middleware counterpart.
+ */
+class DSFMediaTypeTranslator {
+    /**
+     * Given a string representation of a backend defined {@link de.numcodex.feasibility_gui_backend.service.QueryMediaTypes}
+     * translates it into a media type compatible with DSF middleware instances.
+     *
+     * @param mediaType The media type that shall be translated.
+     * @return The translated media type.
+     * @throws UnsupportedMediaTypeException If the given media type is not supported.
+     */
+    public String translate(String mediaType) throws UnsupportedMediaTypeException {
+        return switch (mediaType.toLowerCase()) {
+            case STRUCTURED_QUERY -> "application/json";
+            case CQL -> CQL;
+            case FHIR -> "application/x-fhir-query";
+            default -> throw new UnsupportedMediaTypeException(mediaType, List.of(STRUCTURED_QUERY, CQL, FHIR));
+        };
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryData.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFQueryData.java
@@ -1,0 +1,26 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Wrapper for different DSF query library information separated by different mime types.
+ */
+final class DSFQueryData {
+    private final Map<String, String> contentByType;
+
+    public DSFQueryData() {
+        contentByType = new HashMap<>();
+    }
+
+    public void addQueryContent(String mediaType, String content) {
+        Objects.requireNonNull(mediaType);
+        Objects.requireNonNull(content);
+        contentByType.put(mediaType, content);
+    }
+
+    public Map<String, String> getContentByType() {
+        return contentByType;
+    }
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFSpringConfig.java
@@ -47,8 +47,14 @@ public class DSFSpringConfig {
     }
 
     @Bean
-    QueryManager dsfQueryManager(FhirWebClientProvider fhirWebClientProvider) {
-        return new DSFQueryManager(fhirWebClientProvider, organizationId.replace(' ', '_'));
+    QueryManager dsfQueryManager(FhirWebClientProvider fhirWebClientProvider, DSFMediaTypeTranslator dsfMediaTypeTranslator) {
+        return new DSFQueryManager(fhirWebClientProvider, dsfMediaTypeTranslator,
+                organizationId.replace(' ', '_'));
+    }
+
+    @Bean
+    DSFMediaTypeTranslator dsfMediaTypeTranslator() {
+        return new DSFMediaTypeTranslator();
     }
 
     @Bean
@@ -83,5 +89,5 @@ public class DSFSpringConfig {
         return new DSFFhirWebClientProvider(fhirContext, webserviceBaseUrl, webserviceReadTimeout,
                 webserviceConnectTimeout, websocketUrl, securityContextProvider);
     }
-   
+
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/service/QueryHandlerServiceTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/service/QueryHandlerServiceTest.java
@@ -1,10 +1,5 @@
 package de.numcodex.feasibility_gui_backend.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.numcodex.feasibility_gui_backend.model.db.Query;
 import de.numcodex.feasibility_gui_backend.model.db.Result;
@@ -20,13 +15,19 @@ import de.numcodex.feasibility_gui_backend.service.query_executor.QueryNotFoundE
 import de.numcodex.feasibility_gui_backend.service.query_executor.QueryStatusListener;
 import de.numcodex.feasibility_gui_backend.service.query_executor.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.service.query_executor.UnsupportedMediaTypeException;
-import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -91,7 +92,7 @@ public class QueryHandlerServiceTest {
     when(cqlQueryBuilder.getQueryContent(structuredQuery)).thenReturn("cql_query");
     when(fhirQueryBuilder.getQueryContent(structuredQuery)).thenReturn("fhir_query");
 
-    expectedQuery.getContents().put("text/structured-query", "structured_query");
+    expectedQuery.getContents().put("application/sq+json", "structured_query");
     expectedQuery.getContents().put("text/cql", "cql_query");
     expectedQuery.getContents().put("text/fhir-codex", "fhir_query");
     when(brokerClient.createQuery()).thenReturn("42");
@@ -109,7 +110,7 @@ public class QueryHandlerServiceTest {
     when(cqlQueryBuilder.getQueryContent(structuredQuery)).thenReturn("cql_query");
     when(fhirQueryBuilder.getQueryContent(structuredQuery)).thenReturn("fhir_query");
 
-    expectedQuery.getContents().put("text/structured-query", "structured_query");
+    expectedQuery.getContents().put("application/sq+json", "structured_query");
     expectedQuery.getContents().put("text/cql", "cql_query");
     expectedQuery.getContents().put("text/fhir-codex", "fhir_query");
     when(brokerClient.createQuery()).thenReturn("42");

--- a/src/test/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFMediaTypeTranslatorTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/service/query_executor/impl/dsf/DSFMediaTypeTranslatorTest.java
@@ -1,0 +1,42 @@
+package de.numcodex.feasibility_gui_backend.service.query_executor.impl.dsf;
+
+import de.numcodex.feasibility_gui_backend.service.QueryMediaTypes;
+import de.numcodex.feasibility_gui_backend.service.query_executor.UnsupportedMediaTypeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DSFMediaTypeTranslatorTest {
+
+    private DSFMediaTypeTranslator translator;
+
+    @BeforeEach
+    public void setUp() {
+        translator = new DSFMediaTypeTranslator();
+    }
+
+    @Test
+    public void testTranslate_StructuredQueryMediaType() throws UnsupportedMediaTypeException {
+        var dsfMediaType = translator.translate(QueryMediaTypes.STRUCTURED_QUERY);
+        assertEquals("application/json", dsfMediaType);
+    }
+
+    @Test
+    public void testTranslate_CqlQueryMediaType() throws UnsupportedMediaTypeException {
+        var dsfMediaType = translator.translate(QueryMediaTypes.CQL);
+        assertEquals(QueryMediaTypes.CQL, dsfMediaType);
+    }
+
+    @Test
+    public void testTranslate_FhirQueryMediaType() throws UnsupportedMediaTypeException {
+        var dsfMediaType = translator.translate(QueryMediaTypes.FHIR);
+        assertEquals("application/x-fhir-query", dsfMediaType);
+    }
+
+    @Test
+    public void testTranslate_UnsupportedMediaType() {
+        assertThrows(UnsupportedMediaTypeException.class, () -> translator.translate("something/unsupported"));
+    }
+}


### PR DESCRIPTION
Allows for using media types other than text/cql
for the DSF path. Supported media types are:
- structured query (application/sq+json)
- cql (text/cql)
- fhir (text/fhir-codex)

Media types will get translated so that they are
compatible with the DSF middleware implementation.

Resolves #34.