### PR TITLE
Enhancement/63 run tests on every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,61 @@ on:
 
 jobs:
 
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 15
+
+      - name: Cache Local Maven Repo
+        uses: actions/cache@v2.1.2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo
+
+      - uses: s4u/maven-settings-action@v2.4.0
+        with:
+          servers: |
+            [{"id": "highmed", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"},
+             {"id": "codex", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]
+
+      - name: Run Unit Tests
+        run: mvn surefire:test
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 15
+
+      - name: Cache Local Maven Repo
+        uses: actions/cache@v2.1.2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo
+
+      - uses: s4u/maven-settings-action@v2.4.0
+        with:
+          servers: |
+            [{"id": "highmed", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"},
+             {"id": "codex", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]
+
+      - name: Run Integration Tests
+        run: mvn failsafe:integration-test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [ unit-tests, integration-tests ]
     steps:
       - uses: actions/checkout@v2
 
@@ -39,11 +91,11 @@ jobs:
       - name: Build
         run: mvn -B package
 
-  build:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    needs: test
-    runs-on: ubuntu-latest
 
+  release:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: [build]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-    - master
+    - '**'
     tags:
     - v[0-9]+.[0-9]+.[0-9]+**
   pull_request:


### PR DESCRIPTION
Closes #63.

Ensure tests run on **every** commit. Also splits up workflow jobs into more fine-grained ones (unit-tests + integration-tests + build).