### PR TITLE
Allow Disabling of Unit and Integration Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
              {"id": "codex", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]
 
       - name: Run Unit Tests
-        run: mvn surefire:test
+        run: mvn -B test
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -62,39 +62,11 @@ jobs:
              {"id": "codex", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]
 
       - name: Run Integration Tests
-        run: mvn failsafe:integration-test
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [ unit-tests, integration-tests ]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up JDK 15
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 15
-
-      - name: Cache Local Maven Repo
-        uses: actions/cache@v2.1.2
-        with:
-          path: ~/.m2/repository
-          key: maven-repo
-
-      - uses: s4u/maven-settings-action@v2.4.0
-        with:
-          servers: |
-            [{"id": "highmed", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"},
-             {"id": "codex", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]
-
-      - name: Build
-        run: mvn -B package
-
+        run: mvn -B -DskipUnitTests verify
 
   release:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    needs: [build]
+    needs: [ unit-tests, integration-tests ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -124,7 +96,7 @@ jobs:
         echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
 
     - name: Maven Package
-      run: mvn -B -DskipTests -DskipITs package
+      run: mvn -B -DskipUnitTests -DskipIntegrationTests package
 
     - name: Login to GitHub Docker Registry
       uses: docker/login-action@v1

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,14 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>${skipUnitTests}</skipTests>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.0.0-M5</version>
         <executions>
@@ -224,6 +232,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <skipITs>${skipIntegrationTests}</skipITs>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
closes #74 

Streamlines the testing pipeline in a way so that unit
and integration tests can be disabled separately. Prior
to this change no tests were run since the `surefire:test`
and `failsafe:integration-test` goals did not compile
test classes.