### PR TITLE
Dependency/79 upgrade sq2cql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 15
+          java-version: 17
 
       - name: Cache Local Maven Repo
         uses: actions/cache@v2.1.2
@@ -43,11 +43,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 15
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 15
+          java-version: 17
 
       - name: Cache Local Maven Repo
         uses: actions/cache@v2.1.2
@@ -71,11 +71,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 15
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: 15
+        java-version: 17
 
     - name: Cache Local Maven Repo
       uses: actions/cache@v2.1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:15
+FROM openjdk:17
 
 WORKDIR /opt/codex-feasibility-backend
 COPY ./target/*.jar ./feasibility-gui-backend.jar

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>de.numcodex</groupId>
       <artifactId>sq2cql</artifactId>
-      <version>0.1.3</version>
+      <version>0.1.8</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.4.2</version>
+    <version>2.6.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>de.num-codex</groupId>
@@ -22,7 +22,7 @@
   </scm>
 
   <properties>
-    <java.version>15</java.version>
+    <java.version>17</java.version>
     <mockwebserver.version>4.9.1</mockwebserver.version>
     <okhttp3.version>4.9.1</okhttp3.version>
     <log4j2.version>2.16.0</log4j2.version>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
 
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.7.7</version>
+      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/translation/QueryTranslatorSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/translation/QueryTranslatorSpringConfig.java
@@ -3,9 +3,9 @@ package de.numcodex.feasibility_gui_backend.query.translation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.numcodex.feasibility_gui_backend.query.QueryMediaType;
 import de.numcodex.sq2cql.Translator;
-import de.numcodex.sq2cql.model.ConceptNode;
 import de.numcodex.sq2cql.model.Mapping;
 import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.TermCodeNode;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -76,10 +76,10 @@ public class QueryTranslatorSpringConfig {
     @Bean
     Translator createCqlTranslator(@Qualifier("translation") ObjectMapper jsonUtil) throws IOException {
         var mappings = jsonUtil.readValue(new File(mappingsFile), Mapping[].class);
-        var conceptTree = jsonUtil.readValue(new File(conceptTreeFile), ConceptNode.class);
+        var conceptTree = jsonUtil.readValue(new File(conceptTreeFile), TermCodeNode.class);
         return Translator.of(MappingContext.of(
                 Stream.of(mappings)
-                        .collect(Collectors.toMap(Mapping::getConcept, Function.identity(), (a, b) -> a)),
+                        .collect(Collectors.toMap(Mapping::getKey, Function.identity(), (a, b) -> a)),
                 conceptTree,
                 Map.ofEntries(entry("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "icd10"),
                         entry("http://loinc.org", "loinc"),


### PR DESCRIPTION
Upgrades to the latest sq2cql version. However, doing so also requires an update to Java 17 (new LTS version). The latter is favorable either way since our currently used version already reached its EOL (several month ago).

Closes #79 