### PR TITLE
Bump sq2cql Version to 0.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>de.numcodex</groupId>
       <artifactId>sq2cql</artifactId>
-      <version>0.1.8</version>
+      <version>0.1.10</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Addresses a bug where structured queries containing an
'attributeFilters' keyword could not be translated into
their CQL format.
The new sq2cql version is meant to fix this.

Fixes #83 