### PR TITLE
Fix Race Condition Using Multiple Brokers

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/QueryHandlerService.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import static de.numcodex.feasibility_gui_backend.query.persistence.ResultType.SUCCESS;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class QueryHandlerService {
 
@@ -37,6 +36,7 @@ public class QueryHandlerService {
         return queryId;
     }
 
+    @Transactional
     public QueryResult getQueryResult(Long queryId) {
         var singleSiteResults = resultRepository.findByQueryAndStatus(queryId, SUCCESS);
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/BrokerClient.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/BrokerClient.java
@@ -28,70 +28,72 @@ public interface BrokerClient {
     void addQueryStatusListener(QueryStatusListener queryStatusListener) throws IOException;
 
     /**
-     * Creates a new unpublished query.
+     * Creates a new unpublished broker specific query.
      *
-     * @return The ID of the created query.
+     * @param backendQueryId Identifier for a backend specific query that a broker specific query is created for.
+     * @return Identifier of the broker specific query.
      * @throws IOException IO/communication error
      */
-    String createQuery() throws IOException;
+    String createQuery(Long backendQueryId) throws IOException;
 
     /**
-     * Adds the necessary query definition to a query.
+     * Adds the necessary query definition to a broker specific query.
      * <p>
      * The query definition is added to a query identified by the given query ID.
      *
-     * @param queryId   Identifies the query that the query definition shall be added to.
-     * @param mediaType ?
-     * @param content   The actual query in plain text.
+     * @param brokerQueryId Identifies the broker specific query that the query definition shall be added to.
+     * @param mediaType     MIME type for the query content.
+     * @param content       The actual query in plain text.
      * @throws QueryNotFoundException        If the given query ID does not identify a known query.
      * @throws UnsupportedMediaTypeException If the given media type is not supported.
      * @throws IOException                   IO/communication error
      */
-    void addQueryDefinition(String queryId, String mediaType, String content) throws QueryNotFoundException,
+    void addQueryDefinition(String brokerQueryId, String mediaType, String content) throws QueryNotFoundException,
             UnsupportedMediaTypeException, IOException;
 
     /**
-     * Publishes a query for distributed execution.
+     * Publishes a broker specific query for distributed execution.
      *
-     * @param queryId Identifies the query that shall be published.
+     * @param brokerQueryId Identifies the broker specific query that shall be published.
      * @throws QueryNotFoundException If the given query ID does not identify a known query.
      * @throws IOException            If the query was not published due IO/communication error
      */
-    void publishQuery(String queryId) throws QueryNotFoundException, IOException;
+    void publishQuery(String brokerQueryId) throws QueryNotFoundException, IOException;
 
     /**
-     * Marks an already published query as closed.
+     * Marks an already published broker specific query as closed.
      * <p>
      * After calling this function calls to {@link #getResultFeasibility(String, String)} and
      * {@link #getResultSiteIds(String)} will fail.
      *
-     * @param queryId Identifies the query that shall be closed.
+     * @param brokerQueryId Identifies the broker specific query that shall be closed.
      * @throws QueryNotFoundException If the given query ID does not identify a known query.
      * @throws IOException            IO/communication error
      */
-    void closeQuery(String queryId) throws QueryNotFoundException, IOException;
+    void closeQuery(String brokerQueryId) throws QueryNotFoundException, IOException;
 
     /**
-     * Gets the feasibility (measure count) of a published query for a specific site.
+     * Gets the feasibility (measure count) of a published broker specific query for a specific site.
      *
-     * @param queryId Identifies the query.
-     * @param siteId  Identifies the site within the query whose feasibility shall be gotten.
+     * @param brokerQueryId Identifies the broker specific query.
+     * @param siteId        Identifies the site within the query whose feasibility shall be gotten.
      * @return The feasibility for a specific site within a query.
      * @throws QueryNotFoundException If the given query ID does not identify a known query.
      * @throws SiteNotFoundException  If the given site ID does not identify a known site within a query.
      * @throws IOException            IO/communication error
      */
-    int getResultFeasibility(String queryId, String siteId) throws QueryNotFoundException, SiteNotFoundException, IOException;
+    int getResultFeasibility(String brokerQueryId, String siteId) throws QueryNotFoundException, SiteNotFoundException,
+            IOException;
 
     /**
-     * Gets all site IDs associated with a published query that can already provide a result.
+     * Gets all site IDs associated with a published broker specific query that can already provide a result.
      *
-     * @param queryId Identifies the query whose associated site IDs with results shall be gotten.
+     * @param brokerQueryId Identifies the broker specific query whose associated site IDs with results shall be gotten.
      * @return All site IDs of a specific query that can already provide results.
      * @throws QueryNotFoundException If the given query ID does not identify a known query.
      * @throws IOException            IO/communication error
      */
-    List<String> getResultSiteIds(String queryId) throws QueryNotFoundException, IOException;
+    List<String> getResultSiteIds(String brokerQueryId) throws QueryNotFoundException, IOException;
 
     /**
      * Gets the display name of a site.

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultCollector.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFQueryResultCollector.java
@@ -2,6 +2,7 @@ package de.numcodex.feasibility_gui_backend.query.broker.dsf;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import de.numcodex.feasibility_gui_backend.query.collect.QueryStatusUpdate;
 import de.numcodex.feasibility_gui_backend.query.broker.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.broker.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.collect.QueryStatus;
@@ -74,8 +75,13 @@ class DSFQueryResultCollector implements QueryResultCollector {
 
     private void notifyResultListeners(DSFQueryResult result) {
         for (Entry<DSFBrokerClient, QueryStatusListener> listener : listeners.entrySet()) {
-            listener.getValue().onClientUpdate(listener.getKey(), result.getQueryId(), result.getSiteId(),
+            var broker = listener.getKey();
+            var statusListener = listener.getValue();
+            var statusUpdate = new QueryStatusUpdate(broker, result.getQueryId(), result.getSiteId(),
                     QueryStatus.COMPLETED);
+            var associatedBackendQueryId = broker.getBackendQueryId(result.getQueryId());
+
+            statusListener.onClientUpdate(associatedBackendQueryId, statusUpdate);
         }
     }
 

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/collect/QueryCollectSpringConfig.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/collect/QueryCollectSpringConfig.java
@@ -1,6 +1,6 @@
 package de.numcodex.feasibility_gui_backend.query.collect;
 
-import de.numcodex.feasibility_gui_backend.query.persistence.QueryDispatchRepository;
+import de.numcodex.feasibility_gui_backend.query.persistence.QueryRepository;
 import de.numcodex.feasibility_gui_backend.query.persistence.ResultRepository;
 import de.numcodex.feasibility_gui_backend.query.persistence.SiteRepository;
 import org.springframework.context.annotation.Bean;
@@ -10,9 +10,9 @@ import org.springframework.context.annotation.Configuration;
 public class QueryCollectSpringConfig {
 
     @Bean
-    public QueryStatusListener createQueryStatusListener(QueryDispatchRepository queryDispatchRepository,
+    public QueryStatusListener createQueryStatusListener(QueryRepository queryRepository,
                                                          SiteRepository siteRepository,
                                                          ResultRepository resultRepository) {
-        return new QueryStatusListenerImpl(queryDispatchRepository, siteRepository, resultRepository);
+        return new QueryStatusListenerImpl(queryRepository, siteRepository, resultRepository);
     }
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/collect/QueryStatusListener.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/collect/QueryStatusListener.java
@@ -1,19 +1,16 @@
 package de.numcodex.feasibility_gui_backend.query.collect;
 
-import de.numcodex.feasibility_gui_backend.query.broker.BrokerClient;
-
 /**
- * Represents an entity capable of receiving results from a feasibility query running in a distributed fashion.
+ * Represents an entity capable of receiving results from brokers for broker specific queries that they run.
  */
 public interface QueryStatusListener {
 
     /**
-     * Callback method to process feasibility query result updates.
+     * Processes update notifications from brokers to one of their broker specific queries that is associated with an
+     * internal (backend specific) query.
      *
-     * @param client  The broker client that this update belongs to.
-     * @param queryId Identifies the query within the broker for which there is an update.
-     * @param siteId  Identifies the site within the broker for which there is an update. Related to a specific query.
-     * @param status  New state of the query.
+     * @param backendQueryId    Identifier for a backend specific query that the status update is associated with.
+     * @param queryStatusUpdate Describes the update for a broker specific query.
      */
-    void onClientUpdate(BrokerClient client, String queryId, String siteId, QueryStatus status);
+    void onClientUpdate(Long backendQueryId, QueryStatusUpdate queryStatusUpdate);
 }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/collect/QueryStatusUpdate.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/collect/QueryStatusUpdate.java
@@ -1,0 +1,13 @@
+package de.numcodex.feasibility_gui_backend.query.collect;
+
+import de.numcodex.feasibility_gui_backend.query.broker.BrokerClient;
+
+/**
+ * Defines a status update on a broker specific query.
+ * <p>
+ * Comprises information about the broker that the update originates from, the associated broker specific query ID, the
+ * associated broker specific site ID as well as the query status itself.
+ */
+public record QueryStatusUpdate(BrokerClient source, String brokerQueryId, String brokerSiteId,
+                                QueryStatus status) {
+}

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatcher.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/dispatch/QueryDispatcher.java
@@ -80,7 +80,7 @@ public class QueryDispatcher {
     /**
      * Dispatches (publishes) an already enqueued query in a broadcast fashion using configured {@link BrokerClient}s.
      *
-     * @param queryId Identifies the query that shall be dispatched.
+     * @param queryId Identifies the backend query that shall be dispatched.
      * @throws QueryDispatchException If an error occurs while dispatching the query.
      */
     // TODO: Pass in audit information! (actor)
@@ -92,7 +92,7 @@ public class QueryDispatcher {
         // TODO: error handling + asynchronous dispatch!
         try {
             for (BrokerClient broker : queryBrokerClients) {
-                var brokerQueryId = broker.createQuery();
+                var brokerQueryId = broker.createQuery(queryId);
 
                 for (Entry<QueryMediaType, String> queryBodyFormats : translatedQueryBodyFormats.entrySet()) {
                     broker.addQueryDefinition(brokerQueryId, queryBodyFormats.getKey().getRepresentation(),

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 class DirectBrokerClientTest {
 
+    private static final Long TEST_BACKEND_QUERY_ID = 1L;
+
     @SuppressWarnings("unused")
     @Mock
     WebClient webClient;
@@ -28,7 +30,7 @@ class DirectBrokerClientTest {
 
     @Test
     void testPublishExistingQueryWithoutStructuredQueryDefinition() {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         assertThrows(IllegalStateException.class, () -> client.publishQuery(queryId));
     }
 
@@ -46,7 +48,7 @@ class DirectBrokerClientTest {
 
     @Test
     void testCloseQuery() {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         assertDoesNotThrow(() -> client.closeQuery(queryId));
     }
 
@@ -57,7 +59,7 @@ class DirectBrokerClientTest {
 
     @Test
     void testGetResultFeasibilityForUnknownSite() {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         assertThrows(SiteNotFoundException.class, () -> client.getResultFeasibility(queryId, "unknown-site-id"));
     }
 
@@ -68,7 +70,7 @@ class DirectBrokerClientTest {
 
     @Test
     void testGetResultSiteIdsForUnpublishedQuery() throws QueryNotFoundException {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         var resultSiteIds = client.getResultSiteIds(queryId);
 
         assertTrue(resultSiteIds.isEmpty());

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/mock/MockBrokerClientIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/mock/MockBrokerClientIT.java
@@ -3,6 +3,7 @@ package de.numcodex.feasibility_gui_backend.query.broker.mock;
 import de.numcodex.feasibility_gui_backend.query.broker.QueryNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.broker.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.collect.QueryStatusListener;
+import de.numcodex.feasibility_gui_backend.query.collect.QueryStatusUpdate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.*;
 public class MockBrokerClientIT {
 
     private static final int ASYNC_TIMEOUT_WAIT_MS = 9000;
+    private static final Long TEST_BACKEND_QUERY_ID = 1L;
 
     MockBrokerClient client;
 
@@ -26,36 +28,44 @@ public class MockBrokerClientIT {
 
     @Test
     void testPublishQuery() throws QueryNotFoundException, SiteNotFoundException {
-        var queryId = client.createQuery();
+        var brokerQueryId = client.createQuery(TEST_BACKEND_QUERY_ID);
 
         var statusListener = mock(QueryStatusListener.class);
         client.addQueryStatusListener(statusListener);
-        client.publishQuery(queryId);
+        client.publishQuery(brokerQueryId);
 
-        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(client, queryId, "2", COMPLETED);
-        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(client, queryId, "3", COMPLETED);
-        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(client, queryId, "4", COMPLETED);
-        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(client, queryId, "5", COMPLETED);
+        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "2", COMPLETED));
+        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "3", COMPLETED));
+        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "4", COMPLETED));
+        verify(statusListener, timeout(ASYNC_TIMEOUT_WAIT_MS)).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "5", COMPLETED));
 
-        assertEquals(4, client.getResultSiteIds(queryId).size());
-        assertTrue(client.getResultFeasibility(queryId, "2") >= 10);
-        assertTrue(client.getResultFeasibility(queryId, "3") >= 10);
-        assertTrue(client.getResultFeasibility(queryId, "4") >= 10);
-        assertTrue(client.getResultFeasibility(queryId, "5") >= 10);
+        assertEquals(4, client.getResultSiteIds(brokerQueryId).size());
+        assertTrue(client.getResultFeasibility(brokerQueryId, "2") >= 10);
+        assertTrue(client.getResultFeasibility(brokerQueryId, "3") >= 10);
+        assertTrue(client.getResultFeasibility(brokerQueryId, "4") >= 10);
+        assertTrue(client.getResultFeasibility(brokerQueryId, "5") >= 10);
     }
 
     @Test
     void testCloseQueryWhichIsRunning() throws QueryNotFoundException {
-        var queryId = client.createQuery();
+        var brokerQueryId = client.createQuery(TEST_BACKEND_QUERY_ID);
 
         var statusListener = mock(QueryStatusListener.class);
         client.addQueryStatusListener(statusListener);
-        client.publishQuery(queryId);
-        client.closeQuery(queryId);
+        client.publishQuery(brokerQueryId);
+        client.closeQuery(brokerQueryId);
 
-        verify(statusListener, never()).onClientUpdate(client, queryId, "1", COMPLETED);
-        verify(statusListener, never()).onClientUpdate(client, queryId, "2", COMPLETED);
-        verify(statusListener, never()).onClientUpdate(client, queryId, "3", COMPLETED);
-        verify(statusListener, never()).onClientUpdate(client, queryId, "4", COMPLETED);
+        verify(statusListener, never()).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "1", COMPLETED));
+        verify(statusListener, never()).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "2", COMPLETED));
+        verify(statusListener, never()).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "3", COMPLETED));
+        verify(statusListener, never()).onClientUpdate(TEST_BACKEND_QUERY_ID,
+                new QueryStatusUpdate(client, brokerQueryId, "4", COMPLETED));
     }
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/mock/MockBrokerClientTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/mock/MockBrokerClientTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MockBrokerClientTest {
 
+    private static final Long TEST_BACKEND_QUERY_ID = 1L;
+
     MockBrokerClient client;
 
     @BeforeEach
@@ -23,7 +25,7 @@ class MockBrokerClientTest {
 
     @Test
     void testAddQueryDefinitionToExistingQuery() {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         assertDoesNotThrow(() -> client.addQueryDefinition(queryId, "application/json", ""));
     }
 
@@ -34,7 +36,7 @@ class MockBrokerClientTest {
 
     @Test
     void testCloseQueryWhichHasNotYetBeenPublished() {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         assertDoesNotThrow(() -> client.closeQuery(queryId));
     }
 
@@ -45,7 +47,7 @@ class MockBrokerClientTest {
 
     @Test
     void testGetResultFeasibilityForUnknownSite() {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         assertThrows(SiteNotFoundException.class, () -> client.getResultFeasibility(queryId, "unknown-site-id"));
     }
 
@@ -56,7 +58,7 @@ class MockBrokerClientTest {
 
     @Test
     void testGetResultSiteIdsForUnpublishedQuery() throws QueryNotFoundException {
-        var queryId = client.createQuery();
+        var queryId = client.createQuery(TEST_BACKEND_QUERY_ID);
         var resultSiteIds = client.getResultSiteIds(queryId);
 
         assertTrue(resultSiteIds.isEmpty());


### PR DESCRIPTION
Fixes a race condition that can occur when using
multiple brokers.
For the race condition to occur, one of the brokers
must take a long time to publish a query while
another one already managed to produce a result. This
would lead to a missing database entry since the
dispatch function is transactional over all brokers
and does not commit any transaction until all brokers
have published their query.

In order to prevent this situation from happening, the
database is not used for any sort of component
communication anymore. Instead necessary broker and
backend query ID translations are moved to the broker
implementations.

Fixes #87 