### PR TITLE
Ensure DSF Can Resolve Site Names

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/SiteNotFoundException.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/SiteNotFoundException.java
@@ -4,6 +4,10 @@ package de.numcodex.feasibility_gui_backend.query.broker;
  * Indicates that a site was not found with regards to a specific query.
  */
 public class SiteNotFoundException extends Exception {
+    public SiteNotFoundException(String msg) {
+        super(msg);
+    }
+
     public SiteNotFoundException(String queryId, String siteId) {
         super("Site with ID '" + siteId + "' was not found with regards to query with ID '" + queryId + "'.");
     }

--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFBrokerClient.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFBrokerClient.java
@@ -75,7 +75,10 @@ public final class DSFBrokerClient implements BrokerClient {
 
     @Override
     public String getSiteName(String siteId) throws SiteNotFoundException {
-        // TODO: implement (separate issue)
-        return null;
+        // TODO: replace this identity function with a real resolve routine later on.
+        if (siteId == null) {
+            throw new SiteNotFoundException("cannot find site name of site id with value 'null'");
+        }
+        return siteId;
     }
 }

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFBrokerClientTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/dsf/DSFBrokerClientTest.java
@@ -1,0 +1,30 @@
+package de.numcodex.feasibility_gui_backend.query.broker.dsf;
+
+import de.numcodex.feasibility_gui_backend.query.broker.SiteNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class DSFBrokerClientTest {
+
+    @InjectMocks
+    private DSFBrokerClient client;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"my-site", "something", "identity", "Site 1"})
+    public void testGetSiteName_IsIdentity(String siteId) throws SiteNotFoundException {
+        assertEquals(siteId, client.getSiteName(siteId));
+    }
+
+    @Test
+    public void testGetSiteName_NullRaisesError() {
+        assertThrows(SiteNotFoundException.class, () -> client.getSiteName(null));
+    }
+}


### PR DESCRIPTION
Resolves a site name by using a simple identity function.
Thus, every site ID being specified is returned as is.
This can be used until we have a proper routine for resolving
site names within the DSF context.

Fixes #91 