### PR TITLE
Add Missing JAXB API Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,10 @@
       <artifactId>broker-client</artifactId>
       <version>1.3.2</version>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.highmed.dsf</groupId>


### PR DESCRIPTION
Required in order for Aktin to not run into runtime
issues when communicating with a peer.
JAXB API version is managed by Spring (3.2.1).

Fixes #95 