### PR TITLE
Feature/97 add health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ENV FEASIBILITY_DATABASE_PORT=5432
 ENV FEASIBILITY_DATABASE_USER=postgres
 ENV FEASIBILITY_DATABASE_PASSWORD=password
 
+HEALTHCHECK --interval=5s --start-period=10s CMD curl -s -f http://localhost:8090/actuator/health || exit 1
+
 ENTRYPOINT ["java","-jar","feasibility-gui-backend.jar"]
 
 ARG GIT_REF=""

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -24,6 +24,8 @@ tags:
       url: http://link.to.confluence
   - name: query results
     description: limited CRUD operations for query results (read and update only)
+  - name: intrinsics
+    description: Offers intrinsic information about this application.
 paths:
   /query:
     get:
@@ -343,6 +345,24 @@ paths:
       security:
         - feasibility_auth:
             - delete:result
+  /actuator/health:
+    get:
+      summary: Offers health information about this application.
+      description: ''
+      operationId: ''
+      responses:
+        200:
+          description: Successful health information.
+          content:
+            application/vnd.spring-boot.actuator.v3+json:
+              examples:
+                Healthy Application:
+                  value: |-
+                    {
+                        "status": "UP"
+                    }
+      tags:
+        - intrinsics
 components:
   schemas:
     Query:

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-spring-boot-starter</artifactId>
       <version>12.0.4</version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,12 @@ spring:
           jackis:
             jsonintegration:
               hibernate: CustomPostgreSQL95Dialect
-
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true
 
 app:
   # AKTIN or DSF or MOCK or DIRECT


### PR DESCRIPTION
Adds a simple health endpoint in order to check whether the service is up and running (healthy).
The endpoint is reachable via `/actuator/health`.

Also adds a default health check instruction to the Dockerfile. This instruction can be overwritten by docker-compose consumers if needed.

There are additional, more specific endpoints tailored to the needs of `k8s` consumers. However, they are not enabled by this PR. We should target these things in a separate issue as soon as someone has a need for it.