### PR TITLE
Handle Aktin Result Parse Error

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/aktin/AktinBrokerClient.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/aktin/AktinBrokerClient.java
@@ -6,6 +6,7 @@ import de.numcodex.feasibility_gui_backend.query.broker.SiteNotFoundException;
 import de.numcodex.feasibility_gui_backend.query.broker.UnsupportedMediaTypeException;
 import de.numcodex.feasibility_gui_backend.query.collect.QueryStatusListener;
 import de.numcodex.feasibility_gui_backend.query.persistence.BrokerClientType;
+import lombok.extern.slf4j.Slf4j;
 import org.aktin.broker.client2.BrokerAdmin2;
 import org.aktin.broker.xml.Node;
 import org.aktin.broker.xml.RequestStatusInfo;
@@ -24,6 +25,7 @@ import static de.numcodex.feasibility_gui_backend.query.persistence.BrokerClient
  * @author R.W.Majeed
  *
  */
+@Slf4j
 public class AktinBrokerClient implements BrokerClient {
 	private final BrokerAdmin2 delegate;
 	private final Map<String, Long> brokerToBackendQueryIdMapping;
@@ -92,7 +94,15 @@ public class AktinBrokerClient implements BrokerClient {
 		if( result == null ) {
 			throw new SiteNotFoundException(brokerQueryId, siteId);
 		}
-		return Integer.parseInt(result);
+
+		try {
+			return Integer.parseInt(result);
+		} catch (NumberFormatException e) {
+			log.warn(("returning result of '0' for Aktin broker query with ID '%s' of site '%s' since result can not" +
+					" be parsed as an integer")
+					.formatted(brokerQueryId, siteId), e);
+			return 0;
+		}
 	}
 
 	@Override

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/aktin/AktinBrokerClientTest.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/aktin/AktinBrokerClientTest.java
@@ -1,0 +1,41 @@
+package de.numcodex.feasibility_gui_backend.query.broker.aktin;
+
+import org.aktin.broker.client2.BrokerAdmin2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AktinBrokerClientTest {
+
+    @Mock
+    private BrokerAdmin2 delegate;
+
+    @InjectMocks
+    private AktinBrokerClient client;
+
+    @Test
+    public void testGetResultFeasibility_ReturnsActualPeerResultIfParsable() throws IOException {
+        when(delegate.getResultString(anyInt(), anyInt())).thenReturn("5");
+
+        var result = assertDoesNotThrow(() -> client.getResultFeasibility("1", "1"));
+        assertEquals(5, result);
+    }
+
+    @Test
+    public void testGetResultFeasibility_ReturnsZeroIfPeerSendsNonNumberResult() throws IOException {
+        when(delegate.getResultString(anyInt(), anyInt())).thenReturn("no integer");
+
+        var result = assertDoesNotThrow(() -> client.getResultFeasibility("1", "1"));
+        assertEquals(0, result);
+    }
+}


### PR DESCRIPTION
Handles a case where Aktin fails to retrieve a result
for a specific query + peer resembling an integer.
In this case, it will fall back to return the neutral
element for additions (zero) and logs a warning message.