### PR TITLE
Support Latest Flare Version

### DIFF
--- a/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClient.java
+++ b/src/main/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClient.java
@@ -30,8 +30,7 @@ public class DirectBrokerClient implements BrokerClient {
     private static final String SITE_1_ID = "1";
     private static final String SITE_1_NAME = "FHIR Server";
 
-    private static final String FLARE_REQUEST_CONTENT_TYPE = "application/json";
-    private static final String FLARE_RESPONSE_ACCEPT_CONTENT_TYPE = "CSQ";
+    private static final String FLARE_REQUEST_CONTENT_TYPE = "application/sq+json";
     private static final String FLARE_QUERY_ENDPOINT_URL = "/query/execute";
 
     private final WebClient webClient;
@@ -91,10 +90,6 @@ public class DirectBrokerClient implements BrokerClient {
             webClient.post()
                     .uri(FLARE_QUERY_ENDPOINT_URL)
                     .header(HttpHeaders.CONTENT_TYPE, FLARE_REQUEST_CONTENT_TYPE)
-                    // TODO: Resolve this with the Flare team. This is NOT the header to be used.
-                    //       The accept encoding header should not change the content itself.
-                    //       Thus, it's mainly used for compression algorithms.
-                    .header(HttpHeaders.ACCEPT_ENCODING, FLARE_RESPONSE_ACCEPT_CONTENT_TYPE)
                     .bodyValue(structuredQueryContent)
                     .retrieve()
                     .bodyToMono(String.class)

--- a/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientIT.java
+++ b/src/test/java/de/numcodex/feasibility_gui_backend/query/broker/direct/DirectBrokerClientIT.java
@@ -60,8 +60,7 @@ class DirectBrokerClientIT {
         client.publishQuery(brokerQueryId);
         var recordedRequest = mockWebServer.takeRequest();
 
-        assertEquals("application/json", recordedRequest.getHeader(CONTENT_TYPE));
-        assertEquals("CSQ", recordedRequest.getHeader(ACCEPT_ENCODING));
+        assertEquals("application/sq+json", recordedRequest.getHeader(CONTENT_TYPE));
         assertEquals("POST", recordedRequest.getMethod());
         assertEquals("foo", recordedRequest.getBody().readUtf8());
 


### PR DESCRIPTION
Adds support for the latest Flare version in
development v1.0. These changes support Flare
in version of at least v1.0-RC6.

Mainly adjusts communication headers since in
the past Flare enforced the presence of headers
in an incorrect fashion (headers were used for
things that they were not supposed to).

Resolves #112 